### PR TITLE
Use a peer dependency for scenes instead of a regular dependency

### DIFF
--- a/packages/scenes-ml-app/package.json
+++ b/packages/scenes-ml-app/package.json
@@ -75,7 +75,7 @@
     "@emotion/css": "11.10.6",
     "@grafana/data": "^10.4.1",
     "@grafana/runtime": "^10.4.1",
-    "@grafana/scenes": "^4.26.1",
+    "@grafana/scenes": "^5.3.0",
     "@grafana/scenes-ml": "workspace:*",
     "@grafana/schema": "^10.4.1",
     "@grafana/ui": "^10.4.1",

--- a/packages/scenes-ml/package.json
+++ b/packages/scenes-ml/package.json
@@ -38,12 +38,12 @@
   },
   "dependencies": {
     "@bsull/augurs": "0.2.0",
-    "@grafana/scenes": ">4.26.1",
     "date-fns": "^3.6.0"
   },
   "peerDependencies": {
     "@grafana/data": "^10.0.3",
     "@grafana/runtime": "^10.0.3",
+    "@grafana/scenes": ">=4.26.1",
     "@grafana/schema": "^10.0.3",
     "@grafana/ui": "^10.0.3",
     "react": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4450,7 +4450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/e2e-selectors@npm:10.4.3, @grafana/e2e-selectors@npm:^10.4.1":
+"@grafana/e2e-selectors@npm:10.4.3":
   version: 10.4.3
   resolution: "@grafana/e2e-selectors@npm:10.4.3"
   dependencies:
@@ -4604,7 +4604,6 @@ __metadata:
     "@grafana/data": "npm:^10.0.3"
     "@grafana/eslint-config": "npm:5.1.0"
     "@grafana/runtime": "npm:^10.0.3"
-    "@grafana/scenes": "npm:>4.26.1"
     "@grafana/schema": "npm:^10.0.3"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "npm:^10.0.3"
@@ -4661,6 +4660,7 @@ __metadata:
   peerDependencies:
     "@grafana/data": ^10.0.3
     "@grafana/runtime": ^10.0.3
+    "@grafana/scenes": ">=4.26.1"
     "@grafana/schema": ^10.0.3
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
@@ -4668,9 +4668,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:>4.26.1":
-  version: 5.2.1
-  resolution: "@grafana/scenes@npm:5.2.1"
+"@grafana/scenes@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@grafana/scenes@npm:5.3.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:^11.0.0"
     "@leeoniya/ufuzzy": "npm:^1.0.14"
@@ -4685,28 +4685,7 @@ __metadata:
     "@grafana/ui": ^10.4.1
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/c7e065b099d9ab47b50766dadcd6cb656965b004c59450f88317f54c9989feb3c07ea3b16694b7bd1fafa70156442c943a1e53b2c4a32c71e0b2125903cdc6af
-  languageName: node
-  linkType: hard
-
-"@grafana/scenes@npm:^4.26.1":
-  version: 4.26.1
-  resolution: "@grafana/scenes@npm:4.26.1"
-  dependencies:
-    "@grafana/e2e-selectors": "npm:^10.4.1"
-    "@leeoniya/ufuzzy": "npm:^1.0.14"
-    react-grid-layout: "npm:1.3.4"
-    react-use: "npm:17.4.0"
-    react-virtualized-auto-sizer: "npm:1.0.7"
-    uuid: "npm:^9.0.0"
-  peerDependencies:
-    "@grafana/data": ^10.4.1
-    "@grafana/runtime": ^10.4.1
-    "@grafana/schema": ^10.4.1
-    "@grafana/ui": ^10.4.1
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10/e49ce30295b7cf366799fba255616347d578827122d00e17438ef1d5ccb9237f4ade67e1f4c57d5293b0be7bd7f5d4d89b28f835d294fe658d5891ee816fb405
+  checksum: 10/625b7e009af1b79de8903eb2fbe9e2da3558e229d51e532bbb385bc72c316f9a5df9e1e81caff49e3b245dd1e00a019331f4ce11cdd980fe112917992c80c3c2
   languageName: node
   linkType: hard
 
@@ -20713,7 +20692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nano-css@npm:^5.3.1, nano-css@npm:^5.6.1":
+"nano-css@npm:^5.6.1":
   version: 5.6.1
   resolution: "nano-css@npm:5.6.1"
   dependencies:
@@ -24252,31 +24231,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.4.0":
-  version: 17.4.0
-  resolution: "react-use@npm:17.4.0"
-  dependencies:
-    "@types/js-cookie": "npm:^2.2.6"
-    "@xobotyi/scrollbar-width": "npm:^1.9.5"
-    copy-to-clipboard: "npm:^3.3.1"
-    fast-deep-equal: "npm:^3.1.3"
-    fast-shallow-equal: "npm:^1.0.0"
-    js-cookie: "npm:^2.2.1"
-    nano-css: "npm:^5.3.1"
-    react-universal-interface: "npm:^0.6.2"
-    resize-observer-polyfill: "npm:^1.5.1"
-    screenfull: "npm:^5.1.0"
-    set-harmonic-interval: "npm:^1.0.1"
-    throttle-debounce: "npm:^3.0.1"
-    ts-easing: "npm:^0.2.0"
-    tslib: "npm:^2.1.0"
-  peerDependencies:
-    react: ^16.8.0  || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
-  checksum: 10/98566c4817b00251107824743ea9dff41f167b548bd5f249f6eb9e2ec09388a2de1e89988e4432cead3f8aa83cf706e0255db8a20c0615768c670751973d2761
-  languageName: node
-  linkType: hard
-
 "react-use@npm:17.5.0":
   version: 17.5.0
   resolution: "react-use@npm:17.5.0"
@@ -24309,16 +24263,6 @@ __metadata:
     react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
     react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
   checksum: 10/02101a340bdbe3e40c49dbc52e524eb7ca18832690e91f045a25675600d7adc0a63e800a4ace6a014132adcdcce0e12a8137971de408427a5a3112d7c87c9f3e
-  languageName: node
-  linkType: hard
-
-"react-virtualized-auto-sizer@npm:1.0.7":
-  version: 1.0.7
-  resolution: "react-virtualized-auto-sizer@npm:1.0.7"
-  peerDependencies:
-    react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
-    react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
-  checksum: 10/a16d8ac11a0efa20d44f36a5cf3854027895b806363a409f2ddc07ff92bfc92aaf5b8eee21f3e1b153cee2273db5e5383b6334d4b530d934ed08808ecfb45b9f
   languageName: node
   linkType: hard
 
@@ -25454,7 +25398,7 @@ __metadata:
     "@grafana/eslint-config": "npm:^7.0.0"
     "@grafana/plugin-meta-extractor": "npm:^0.0.2"
     "@grafana/runtime": "npm:^10.4.1"
-    "@grafana/scenes": "npm:^4.26.1"
+    "@grafana/scenes": "npm:^5.3.0"
     "@grafana/scenes-ml": "workspace:*"
     "@grafana/schema": "npm:^10.4.1"
     "@grafana/tsconfig": "npm:1.3.0-rc1"


### PR DESCRIPTION
`scenes-ml` needs a single version of scenes to be used to ensure we're using the same objects as callers. This PR should avoid us accidentally installing multiple versions.