### PR TITLE
ci: don't specify now-nonexistent token

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -38,8 +38,6 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_ADMIN_TOKEN }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -37,7 +37,16 @@ jobs:
     needs: test
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
@@ -56,6 +65,6 @@ jobs:
       - name: Run auto shipit
         run: yarn auto shipit
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use GitHub apps instead of a nonexistent secret in CI.

I'm currently waiting for a GitHub app to be transferred into the Grafana org before I can install it and use it here.