### PR TITLE
Bump versions to v0.4.0 and update changelogs [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,52 @@
+# v0.4.0 (Wed Nov 13 2024)
+
+Accidental release due to CI issues, no changes since v0.3.0.
+
+---
+
+# v0.3.0 (Wed Nov 13 2024)
+
+ #### 🚀 Enhancement
+
+- `grafana-scenes-ml`
+  - chore: bump several deps [#51](https://github.com/grafana/scenes-ml/pull/51) ([@sd2k](https://github.com/sd2k))
+  - Bump webpack from 5.91.0 to 5.94.0 [#35](https://github.com/grafana/scenes-ml/pull/35) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+  - Bump express from 4.19.2 to 4.21.1 [#47](https://github.com/grafana/scenes-ml/pull/47) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+
+#### 🐛 Bug Fix
+
+- `grafana-scenes-ml`
+  - ci: don't use custom github action for yarn install [#52](https://github.com/grafana/scenes-ml/pull/52) ([@sd2k](https://github.com/sd2k))
+  - Bump rollup from 2.79.1 to 2.79.2 in /packages/scenes-ml [#41](https://github.com/grafana/scenes-ml/pull/41) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@sd2k](https://github.com/sd2k))
+  - Bump http-proxy-middleware from 2.0.6 to 2.0.7 [#49](https://github.com/grafana/scenes-ml/pull/49) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+  - Bump fast-loops from 1.1.3 to 1.1.4 [#33](https://github.com/grafana/scenes-ml/pull/33) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+  - feat: add SceneTimeSeriesClusterer component [#48](https://github.com/grafana/scenes-ml/pull/48) ([@sd2k](https://github.com/sd2k))
+  - fix: use === instead of == [#44](https://github.com/grafana/scenes-ml/pull/44) ([@sd2k](https://github.com/sd2k))
+  - chore: bump @bsull/augurs to 0.6.0 [#46](https://github.com/grafana/scenes-ml/pull/46) ([@sd2k](https://github.com/sd2k))
+  - ci: don't specify now-nonexistent token [#39](https://github.com/grafana/scenes-ml/pull/39) ([@sd2k](https://github.com/sd2k))
+  - feat: add support for MAD outlier detection [#43](https://github.com/grafana/scenes-ml/pull/43) ([@sd2k](https://github.com/sd2k))
+  - feat: add Prophet model option to baseliner [#42](https://github.com/grafana/scenes-ml/pull/42) ([@sd2k](https://github.com/sd2k))
+  - SceneOutlierDetector: fix series number in callback [#34](https://github.com/grafana/scenes-ml/pull/34) ([@matyax](https://github.com/matyax))
+  - Bump ws from 7.5.9 to 7.5.10 [#32](https://github.com/grafana/scenes-ml/pull/32) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+
+#### ⚠️ Pushed to `main`
+
+- `grafana-scenes-ml`
+  - Remove @types/lodash from dependencies ([@sd2k](https://github.com/sd2k))
+
+#### 🔩 Dependency Updates
+
+- `grafana-scenes-ml`
+  - chore: bump yarn to 4.5.1 [#50](https://github.com/grafana/scenes-ml/pull/50) ([@sd2k](https://github.com/sd2k))
+
+#### Authors: 3
+
+- [@dependabot[bot]](https://github.com/dependabot[bot])
+- Ben Sully ([@sd2k](https://github.com/sd2k))
+- Matias Chomicki ([@matyax](https://github.com/matyax))
+
+---
+
 # v0.2.0 (Tue Jun 25 2024)
 
 #### 🚀 Enhancement

--- a/docusaurus/website/package.json
+++ b/docusaurus/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "private": true,
   "name": "grafana-scenes-ml",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Grafana framework for building dynamic dashboards",
   "keywords": [
     "typescript"

--- a/packages/scenes-ml-app/package.json
+++ b/packages/scenes-ml-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scenes-ml-app",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.4.0",
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "description": "A basic Grafana app plugin with demos of the Scenes ML components",

--- a/packages/scenes-ml/CHANGELOG.md
+++ b/packages/scenes-ml/CHANGELOG.md
@@ -1,3 +1,52 @@
+# v0.4.0 (Wed Nov 13 2024)
+
+Accidental release due to CI issues, no changes since v0.3.0.
+
+---
+
+# v0.3.0 (Wed Nov 13 2024)
+
+ #### 🚀 Enhancement
+
+- `grafana-scenes-ml`
+  - chore: bump several deps [#51](https://github.com/grafana/scenes-ml/pull/51) ([@sd2k](https://github.com/sd2k))
+  - Bump webpack from 5.91.0 to 5.94.0 [#35](https://github.com/grafana/scenes-ml/pull/35) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+  - Bump express from 4.19.2 to 4.21.1 [#47](https://github.com/grafana/scenes-ml/pull/47) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+
+#### 🐛 Bug Fix
+
+- `grafana-scenes-ml`
+  - ci: don't use custom github action for yarn install [#52](https://github.com/grafana/scenes-ml/pull/52) ([@sd2k](https://github.com/sd2k))
+  - Bump rollup from 2.79.1 to 2.79.2 in /packages/scenes-ml [#41](https://github.com/grafana/scenes-ml/pull/41) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@sd2k](https://github.com/sd2k))
+  - Bump http-proxy-middleware from 2.0.6 to 2.0.7 [#49](https://github.com/grafana/scenes-ml/pull/49) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+  - Bump fast-loops from 1.1.3 to 1.1.4 [#33](https://github.com/grafana/scenes-ml/pull/33) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+  - feat: add SceneTimeSeriesClusterer component [#48](https://github.com/grafana/scenes-ml/pull/48) ([@sd2k](https://github.com/sd2k))
+  - fix: use === instead of == [#44](https://github.com/grafana/scenes-ml/pull/44) ([@sd2k](https://github.com/sd2k))
+  - chore: bump @bsull/augurs to 0.6.0 [#46](https://github.com/grafana/scenes-ml/pull/46) ([@sd2k](https://github.com/sd2k))
+  - ci: don't specify now-nonexistent token [#39](https://github.com/grafana/scenes-ml/pull/39) ([@sd2k](https://github.com/sd2k))
+  - feat: add support for MAD outlier detection [#43](https://github.com/grafana/scenes-ml/pull/43) ([@sd2k](https://github.com/sd2k))
+  - feat: add Prophet model option to baseliner [#42](https://github.com/grafana/scenes-ml/pull/42) ([@sd2k](https://github.com/sd2k))
+  - SceneOutlierDetector: fix series number in callback [#34](https://github.com/grafana/scenes-ml/pull/34) ([@matyax](https://github.com/matyax))
+  - Bump ws from 7.5.9 to 7.5.10 [#32](https://github.com/grafana/scenes-ml/pull/32) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+
+#### ⚠️ Pushed to `main`
+
+- `grafana-scenes-ml`
+  - Remove @types/lodash from dependencies ([@sd2k](https://github.com/sd2k))
+
+#### 🔩 Dependency Updates
+
+- `grafana-scenes-ml`
+  - chore: bump yarn to 4.5.1 [#50](https://github.com/grafana/scenes-ml/pull/50) ([@sd2k](https://github.com/sd2k))
+
+#### Authors: 3
+
+- [@dependabot[bot]](https://github.com/dependabot[bot])
+- Ben Sully ([@sd2k](https://github.com/sd2k))
+- Matias Chomicki ([@matyax](https://github.com/matyax))
+
+---
+
 # v0.2.0 (Tue Jun 25 2024)
 
 #### 🚀 Enhancement

--- a/packages/scenes-ml/package.json
+++ b/packages/scenes-ml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/scenes-ml",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Machine Learning extensions to Grafana Scenes",
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
CI failed on main so the changes made by the auto bot didn't get pushed
up to the repo.
