### PR TITLE
chore: loosen @grafana/* dependency versions

### DIFF
--- a/packages/scenes-ml/package.json
+++ b/packages/scenes-ml/package.json
@@ -42,11 +42,11 @@
     "date-fns": "^3.6.0"
   },
   "peerDependencies": {
-    "@grafana/data": "^10.0.3",
-    "@grafana/runtime": "^10.0.3",
+    "@grafana/data": ">=10.4",
+    "@grafana/runtime": ">=10.4",
     "@grafana/scenes": ">=4.26.1",
-    "@grafana/schema": "^10.0.3",
-    "@grafana/ui": "^10.0.3",
+    "@grafana/schema": ">=10.4",
+    "@grafana/ui": ">=10.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,11 +4899,11 @@ __metadata:
     tslib: "npm:2.8.1"
     typescript: "npm:5.6.3"
   peerDependencies:
-    "@grafana/data": ^10.0.3
-    "@grafana/runtime": ^10.0.3
+    "@grafana/data": ">=10.4"
+    "@grafana/runtime": ">=10.4"
     "@grafana/scenes": ">=4.26.1"
-    "@grafana/schema": ^10.0.3
-    "@grafana/ui": ^10.0.3
+    "@grafana/schema": ">=10.4"
+    "@grafana/ui": ">=10.4"
     react: ^18.0.0
     react-dom: ^18.0.0
   languageName: unknown


### PR DESCRIPTION
Similar to @grafana/scenes itself we shouldn't be pinning major versions
of the @grafana/* dependencies.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.1--canary.56.12910428337.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install grafana-scenes-ml@0.4.1--canary.56.12910428337.0
  npm install website@0.4.1--canary.56.12910428337.0
  npm install scenes-ml-app@0.4.1--canary.56.12910428337.0
  npm install @grafana/scenes-ml@0.4.1--canary.56.12910428337.0
  # or 
  yarn add grafana-scenes-ml@0.4.1--canary.56.12910428337.0
  yarn add website@0.4.1--canary.56.12910428337.0
  yarn add scenes-ml-app@0.4.1--canary.56.12910428337.0
  yarn add @grafana/scenes-ml@0.4.1--canary.56.12910428337.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
