### PR TITLE
docs: point to Getting Started guide in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See that library for more information on the underlying algorithms.
 
 ## Usage
 
-See the [library README](./packages/scenes-ml/README.md) for usage documentation.
+See the [Getting Started guide][getting-started] for usage documentation.
 
 ## Development
 
@@ -47,5 +47,6 @@ To work on `@grafana/scenes-ml`, please follow the guides below.
 Alternatively, use the [demo app](./packages/scenes-ml-app/README.md) included in this repository.
 
 [augurs]: https://github.com/grafana/augurs
+[getting-started]: https://grafana.com/developers/scenes/scenes-ml/getting-started
 [update-create-plugin-version]: https://grafana.com/developers/plugin-tools/migration-guides/update-create-plugin-versions
 [extend-configuration]: https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/extend-configurations#3-update-the-packagejson-to-use-the-new-webpack-config

--- a/packages/scenes-ml/README.md
+++ b/packages/scenes-ml/README.md
@@ -31,5 +31,8 @@ See that library for more information on the underlying algorithms.
    This is important to make sure your plugin's Webpack configuration knows how to load the package.
 1. Import components from `@grafana/scenes-ml` and use as normal!
 
+See the [Getting Started guide][getting-started] for more usage documentation.
+
 [augurs]: https://github.com/grafana/augurs
+[getting-started]: https://grafana.com/developers/scenes/scenes-ml/getting-started
 [update-create-plugin-version]: https://grafana.com/developers/plugin-tools/migration-guides/update-create-plugin-versions


### PR DESCRIPTION
These docs didn't exist when I initially wrote this README, but we
should point to them now they do.
